### PR TITLE
PCR-184 Carousel takes time and get stuck for some slides

### DIFF
--- a/src/carousel/Carousel.js
+++ b/src/carousel/Carousel.js
@@ -832,6 +832,7 @@ export default class Carousel extends Component {
     }
 
     _onTouchStart () {
+        if(IS_IOS){
         const { onTouchStart } = this.props
 
         // `onTouchStart` is fired even when `scrollEnabled` is set to `false`
@@ -843,8 +844,10 @@ export default class Carousel extends Component {
             onTouchStart()
         }
     }
+    }
 
     _onTouchEnd () {
+        if(IS_IOS){
         const { onTouchEnd } = this.props
 
         if (this._getScrollEnabled() !== false && this._autoplay && !this._autoplaying) {
@@ -855,6 +858,7 @@ export default class Carousel extends Component {
         if (onTouchEnd) {
             onTouchEnd()
         }
+      }
     }
 
     // Used when `enableSnap` is ENABLED


### PR DESCRIPTION
Description:-
Touch End event actually not working in android. User once press _Touchstart then it's pause carousel and touchEnd it should be called to slide again carousel but in android it's not working and managed in onscrollEnd. So i keep Touchstart and touchEnd for IOS only.

<img width="1680" alt="Screenshot 2020-07-17 at 3 24 51 PM" src="https://user-images.githubusercontent.com/55088652/87774136-c6164880-c841-11ea-8eef-4b8b44910d9f.png">
